### PR TITLE
Supporting byte array messages.

### DIFF
--- a/Yacs/Events/ByteMessageReceivedEventArgs.cs
+++ b/Yacs/Events/ByteMessageReceivedEventArgs.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Text;
 
 namespace Yacs.Events
 {
     /// <summary>
-    /// Contains arguments for when a new message is received.
+    /// Contains arguments for when a new byte array message is received.
     /// </summary>
-    public class MessageReceivedEventArgs : EventArgs
+    public class ByteMessageReceivedEventArgs : EventArgs
     {
         /// <summary>
         /// Gets the client's end point.
@@ -17,9 +14,9 @@ namespace Yacs.Events
         /// <summary>
         /// Gets the message received.
         /// </summary>
-        public string Message { get; private set; }
+        public byte[] Message { get; private set; }
         
-        internal MessageReceivedEventArgs(ChannelIdentifier remoteEndPoint, string message)
+        internal ByteMessageReceivedEventArgs(ChannelIdentifier remoteEndPoint, byte[] message)
         {
             EndPoint = remoteEndPoint;
             Message = message;

--- a/Yacs/Events/StringMessageReceivedEventArgs.cs
+++ b/Yacs/Events/StringMessageReceivedEventArgs.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace Yacs.Events
+{
+    /// <summary>
+    /// Contains arguments for when a new string message is received.
+    /// </summary>
+    public class StringMessageReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the client's end point.
+        /// </summary>
+        public ChannelIdentifier EndPoint { get; private set; }
+        /// <summary>
+        /// Gets the message received.
+        /// </summary>
+        public string Message { get; private set; }
+        
+        internal StringMessageReceivedEventArgs(ChannelIdentifier remoteEndPoint, string message)
+        {
+            EndPoint = remoteEndPoint;
+            Message = message;
+        }
+
+    }
+}

--- a/Yacs/IChannel.cs
+++ b/Yacs/IChannel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Yacs.Events;
+using Yacs.Options;
 
 namespace Yacs
 {
@@ -14,15 +15,28 @@ namespace Yacs
         ChannelIdentifier Identifier { get; }
 
         /// <summary>
-        /// Sends a message through the channel.
+        /// Sends a message through the channel. This method will throw an <see cref="InvalidOperationException"/> if the channel has no <see cref="BaseOptions.Encoder"/> set.
         /// </summary>
         /// <param name="message">The message to send.</param>
+        /// <exception cref="InvalidOperationException"></exception>
         void Send(string message);
 
         /// <summary>
-        /// Event triggered to indicate there is a new message.
+        /// Sends a message through the channel. This method will throw an <see cref="InvalidOperationException"/> if the channel has an <see cref="BaseOptions.Encoder"/> set.
         /// </summary>
-        event EventHandler<MessageReceivedEventArgs> MessageReceived;
+        /// <param name="message">The message to send.</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        void Send(byte[] message);
+
+        /// <summary>
+        /// Event triggered to indicate there is a new string message.
+        /// </summary>
+        event EventHandler<StringMessageReceivedEventArgs> StringMessageReceived;
+
+        /// <summary>
+        /// Event triggered to indicate there is a new byte array message.
+        /// </summary>
+        event EventHandler<ByteMessageReceivedEventArgs> ByteMessageReceived;
 
         /// <summary>
         /// Event triggered to indicate the <see cref="IChannel"/> connection was lost.

--- a/Yacs/IServer.cs
+++ b/Yacs/IServer.cs
@@ -28,11 +28,20 @@ namespace Yacs
         int ChannelCount { get; }
 
         /// <summary>
-        /// Sends data to a specific <see cref="IChannel"/>.
+        /// Sends a message to the <see cref="IChannel"/> specified. This method will throw an <see cref="InvalidOperationException"/> if the channel has no <see cref="BaseOptions.Encoder"/> set.
         /// </summary>
         /// <param name="destination">The identifier of the <see cref="IChannel"/> to which the message should be sent.</param>
-        /// <param name="message">The message to send.</param>
+        /// <param name="message">The string message to send.</param>
+        /// <exception cref="InvalidOperationException"></exception>
         void Send(ChannelIdentifier destination, string message);
+
+        /// <summary>
+        /// Sends a message to the <see cref="IChannel"/> specified. This method will throw an <see cref="InvalidOperationException"/> if the channel has an <see cref="BaseOptions.Encoder"/> set.
+        /// </summary>
+        /// <param name="destination">The identifier of the <see cref="IChannel"/> to which the message should be sent.</param>
+        /// <param name="message">The byte message to send.</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        void Send(ChannelIdentifier destination, byte[] message);
 
         /// <summary>
         /// Gets a value indicating whether a specific <see cref="IChannel"/> is online.
@@ -66,9 +75,14 @@ namespace Yacs
         event EventHandler<ConnectionLostEventArgs> ConnectionLost;
 
         /// <summary>
-        /// Event triggered when a message is received from an <see cref="IChannel"/>.
+        /// Event triggered when a string message is received from an <see cref="IChannel"/>.
         /// </summary>
-        event EventHandler<MessageReceivedEventArgs> MessageReceived;
+        event EventHandler<StringMessageReceivedEventArgs> StringMessageReceived;
+
+        /// <summary>
+        /// Event triggered when a byte array message is received from an <see cref="IChannel"/>.
+        /// </summary>
+        event EventHandler<ByteMessageReceivedEventArgs> ByteMessageReceived;
 
         /// <summary>
         /// Event triggered when an <see cref="IChannel"/> throws an error.

--- a/Yacs/Options/BaseOptions.cs
+++ b/Yacs/Options/BaseOptions.cs
@@ -8,7 +8,7 @@ namespace Yacs.Options
     public abstract class BaseOptions
     {
         /// <summary>
-        /// Gets or sets the encoding used for communication. Default: UTF-8
+        /// Gets or sets the encoding used for communication. If this value is null, then messages will be byte arrays instead of strings. Default: UTF-8
         /// </summary>
         public Encoding Encoder { get; set; }
 


### PR DESCRIPTION
- Added support to send byte array messages directly, so the encoding can be avoided
- Added validation on sending messages, so it is not possible to send strings without encoder or byte arrays with one selected
- Added a new encoding algorithm to increase reliability