### PR TITLE
Exceptions/events refactor

### DIFF
--- a/Yacs/Exceptions/OfflineChannelException.cs
+++ b/Yacs/Exceptions/OfflineChannelException.cs
@@ -8,17 +8,17 @@ namespace Yacs.Exceptions
     public class OfflineChannelException : Exception
     {
         /// <summary>
-        /// Gets the <see cref="EndPoint"/> that seems offline.
+        /// Gets the <see cref="Channel"/> that seems offline.
         /// </summary>
-        public ChannelIdentifier EndPoint { get; private set; }
+        public ChannelIdentifier Channel { get; private set; }
 
         /// <summary>
         /// Creates a new <see cref="OfflineChannelException"/>.
         /// </summary>
-        /// <param name="remoteEndpoint"></param>
-        public OfflineChannelException(ChannelIdentifier remoteEndpoint) : base($"The endpoint {remoteEndpoint} is not registered as an online client.")
+        /// <param name="channelIdentifier"></param>
+        public OfflineChannelException(ChannelIdentifier channelIdentifier) : base($"The endpoint {channelIdentifier} is not registered as an online client.")
         {
-            EndPoint = remoteEndpoint;
+            Channel = channelIdentifier;
         }
     }
 }

--- a/Yacs/Exceptions/SendMessageException.cs
+++ b/Yacs/Exceptions/SendMessageException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Yacs.Exceptions
+{
+    /// <summary>
+    /// Represents an error while trying to send a message.
+    /// </summary>
+    public class SendMessageException : Exception
+    {
+        /// <summary>
+        /// Gets the <see cref="ChannelIdentifier"/> that failed sending.
+        /// </summary>
+        public ChannelIdentifier Channel { get; private set; }
+
+        /// <summary>
+        /// Creates a new <see cref="SendMessageException"/>.
+        /// </summary>
+        /// <param name="channelIdentifier"></param>
+        /// <param name="exception"></param>
+        public SendMessageException(ChannelIdentifier channelIdentifier, Exception exception) : base("Error sending message", exception)
+        {
+            Channel = channelIdentifier;
+        }
+    }
+}

--- a/Yacs/Options/ChannelOptions.cs
+++ b/Yacs/Options/ChannelOptions.cs
@@ -8,16 +8,16 @@ namespace Yacs.Options
     public class ChannelOptions : BaseOptions
     {
         /// <summary>
-        /// Gets or sets the KeepAlive option. When this option is enabled, the channel will periodically check if the communication is correct, triggering a <see cref="Events.ConnectionLostEventArgs"/> when it is not successful.
+        /// Gets or sets the active monitoring option. When this option is enabled, the channel will periodically check if the communication is correct, triggering a <see cref="Events.ConnectionLostEventArgs"/> when it is not successful.
         /// </summary>
-        public bool KeepAlive { get; set; }
+        public bool ActiveMonitoring { get; set; }
 
         /// <summary>
         /// Creates new <see cref="ChannelOptions"/> with the default values.
         /// </summary>
         public ChannelOptions() : base()
         {
-            KeepAlive = false;
+            ActiveMonitoring = false;
         }
     }
 }

--- a/Yacs/Server.cs
+++ b/Yacs/Server.cs
@@ -75,7 +75,7 @@ namespace Yacs
             {
                 Encoder = _options.Encoder,
                 ReceptionBufferSize = _options.ReceptionBufferSize,
-                KeepAlive = _options.ActiveChannelMonitoring
+                ActiveMonitoring = _options.ActiveChannelMonitoring
             };
 
             if (_options.IsDiscoverable)


### PR DESCRIPTION
- Added new SendMessageException for problems on send methods.
- Send methods can either work or stop the channel and throw exceptions, they don't trigger events anymore.
- Disconnection events are only triggered by the channel thread.
- KeepAlive option renamed to ActiveMonitoring, which reflects better what the option does.