### PR TITLE
Breaking the channel loop on cancel, instead of returning.

### DIFF
--- a/Yacs/Channel.cs
+++ b/Yacs/Channel.cs
@@ -258,7 +258,7 @@ namespace Yacs
                     }
                     if (_source.Token.IsCancellationRequested)
                     {
-                        return;
+                        break;
                     }
 
                     Thread.Sleep(DEFAULT_DELAY);


### PR DESCRIPTION
That way we always trigger a disconnection event on cancellation.